### PR TITLE
feat: async support + tests

### DIFF
--- a/nigeria_geodata/async_core.py
+++ b/nigeria_geodata/async_core.py
@@ -13,30 +13,25 @@ import abc
 
 class AsyncBaseDataSource(metaclass=abc.ABCMeta):
     """
-    BaseData Factory.
+    AsyncBaseData Factory.
 
-    Abstract Base Class which defines most inputs and methods used by the geo data source.
+    Async Abstract Base Class which defines most inputs and methods used by the geo data source.
 
     """
 
     @abc.abstractmethod
     async def list_data(self):
-        """Provides an async interface to list all available data from the data source."""
+        """Provides an interface to list all available data from the data source."""
         raise NotImplementedError
 
     @abc.abstractmethod
     async def search(self):
-        """Provides an async interface to search for available data from the inheriting data source."""
+        """Provides an interface to search for available data from the data source."""
         raise NotImplementedError
 
     @abc.abstractmethod
-    async def download(self):
-        """Provides an async interface to download available data from the inheriting data source."""
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    async def export(self):
-        """Provides an async interface to export data into different formats."""
+    async def filter(self):
+        """Provides an interface to filter data from the data source."""
         raise NotImplementedError
 
     def __repr__(self) -> str:

--- a/nigeria_geodata/benchmark.py
+++ b/nigeria_geodata/benchmark.py
@@ -1,0 +1,40 @@
+import time
+import asyncio
+from nigeria_geodata.datasources import Grid3
+from nigeria_geodata.datasources import AsyncGrid3
+
+
+# the healthcare data has over 40k rows
+# so testing it with it will give an idea of the performance in a realworld usecase
+def benchmark_sync():
+    grid3 = Grid3()
+    start_time = time.time()
+    grid3.filter(
+        "NGA_HealthFacilities_v1_72",
+        "abuja",
+    )
+    elapsed_time = time.time() - start_time
+    print(f"Synchronous call took {elapsed_time:.2f} seconds")
+
+
+async def benchmark_async():
+    grid3 = AsyncGrid3()
+    start_time = time.time()
+    await grid3.filter("NGA_HealthFacilities_v1_72", "abuja")
+    elapsed_time = time.time() - start_time
+    print(f"Asynchronous call took {elapsed_time:.2f} seconds")
+
+
+def run_benchmarks():
+    print("Starting synchronous benchmark...")
+    benchmark_sync()
+
+    print("Starting asynchronous benchmark...")
+    asyncio.run(benchmark_async())
+
+
+if __name__ == "__main__":
+    run_benchmarks()
+    # sync took 4.58 seconds
+    # async took 0.98 seconds
+    # machine - MBP 16inch. M3, 36 GB RAM.

--- a/nigeria_geodata/core.py
+++ b/nigeria_geodata/core.py
@@ -29,5 +29,10 @@ class SyncBaseDataSource(metaclass=abc.ABCMeta):
         """Provides an interface to search for available data from the data source."""
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def filter(self):
+        """Provides an interface to filter data from the data source."""
+        raise NotImplementedError
+
     def __repr__(self) -> str:
         return "<SyncBaseDataFactory>"

--- a/nigeria_geodata/datasources/__init__.py
+++ b/nigeria_geodata/datasources/__init__.py
@@ -1,3 +1,3 @@
-from .grid3 import Grid3
+from .grid3 import Grid3, AsyncGrid3
 
-__all__ = ["Grid3"]
+__all__ = ["Grid3", "AsyncGrid3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ pre-commit = "^3.7.1"
 pytest = "^8.3.2"
 pandas = "^2.2.2"
 geopandas = "^1.0.1"
+pytest-asyncio = "^0.23.8"
 
 
 [build-system]


### PR DESCRIPTION
Added async support.

To avoid repetitions, I used threading to run the async code. Unfortunately, I couldn't use the httpx async client. However, after benchmarking there's some performance gain. See `benchmark.py`

If need be, we can come back to this later to improve the structure.

Closes https://github.com/jeafreezy/nigeria_geodata/issues/6